### PR TITLE
Fix config serialize in worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.0.3] - 2019-11-25
+### Fixed
+- Only passes `storeName` from storage config to worker to prevent serialization issues.
+
 ## [1.0.2] - 2019-11-25
 ### Changed
 - Expanded README.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [1.0.3] - 2019-11-25
+## [1.0.3] - 2020-09-18
 ### Fixed
 - Only passes `storeName` from storage config to worker to prevent serialization issues.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paysera/redux-state-restore",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Provides tools to persist current redux state to local storage and reinitialize it based on requirements",
   "main": "dist/main.js",
   "scripts": {

--- a/src/storage/worker.js
+++ b/src/storage/worker.js
@@ -13,38 +13,38 @@ const worker = new PromiseWorker(new StorageWorker());
 
 const debouncedSetItems = {};
 
-const storeItem = (storageConfig, identifier, state) => worker.postMessage({
-    storageConfig,
+const storeItem = ({ storeName }, identifier, state) => worker.postMessage({
+    storageConfig: { storeName },
     identifier,
     state,
     type: STORAGE_SAVE,
 });
 
-const initiate = (storageConfig) => {
-    debouncedSetItems[storageConfig.storeName] = debounce(storeItem, 500);
+const initiate = ({ storeName }) => {
+    debouncedSetItems[storeName] = debounce(storeItem, 500);
     worker.postMessage({
-        storageConfig,
+        storageConfig: { storeName },
         type: STORAGE_INITIATE,
     });
 };
 
-const setItem = (storageConfig, identifier, state) => {
-    debouncedSetItems[storageConfig.storeName](storageConfig, identifier, state);
+const setItem = ({ storeName }, identifier, state) => {
+    debouncedSetItems[storeName]({ storeName }, identifier, state);
 };
 
-const removeItem = (storageConfig, identifier) => worker.postMessage({
-    storageConfig,
+const removeItem = ({ storeName }, identifier) => worker.postMessage({
+    storageConfig: { storeName },
     identifier,
     type: STORAGE_REMOVE,
 });
 
-const keys = storageConfig => worker.postMessage({
-    storageConfig,
+const keys = ({ storeName }) => worker.postMessage({
+    storageConfig: { storeName },
     type: STORAGE_KEYS,
 });
 
-const getItem = (storageConfig, identifier) => worker.postMessage({
-    storageConfig,
+const getItem = ({ storeName }, identifier) => worker.postMessage({
+    storageConfig: { storeName },
     identifier,
     type: STORAGE_GET,
 });


### PR DESCRIPTION
storageConfig Object may contain functions, which cannot be passed to worker, causing it to fail in some browsers.
This pull request ensures that only name (which is the only part required for worker from the config) is passed.